### PR TITLE
add astropy and sbypy to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ nbsphinx
 ipython
 jupytext
 jupyter
+astropy
+sbpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ dynamic = ["version"]
 dependencies = [
     "ipykernel", # Support for Jupyter notebooks
     "numpy",
-    "lsst-rsp"
+    "lsst-rsp",
+    "astropy",
+    "sbpy"
 ]
 
 [project.urls]


### PR DESCRIPTION
add astropy and sbypy to requirements both for docs (for future demo notebooks) and for pip installation

Fixes #45

- [X] Does pip install still work?
