### PR TITLE
add matplotlib requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ jupytext
 jupyter
 astropy
 sbpy
+matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "lsst-rsp",
     "astropy",
     "sbpy",
-    "matplotlib" # plotting for demo notebooks
+    "matplotlib" # for plotting
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "numpy",
     "lsst-rsp",
     "astropy",
-    "sbpy"
+    "sbpy",
+    "matplotlib" # plotting for demo notebooks
 ]
 
 [project.urls]


### PR DESCRIPTION
added matplotlib to the requirements to enable plotting with the demo notebooks

Fixes #61 

- [x] Does pip install still work?