### PR TITLE
Adding dates functionality.

### DIFF
--- a/src/adler/adler.py
+++ b/src/adler/adler.py
@@ -4,7 +4,7 @@ from adler.dataclasses.AdlerPlanetoid import AdlerPlanetoid
 
 
 def runAdler(args):
-    planetoid = AdlerPlanetoid.construct_from_RSP(args.ssoid, args.filter_list)
+    planetoid = AdlerPlanetoid.construct_from_RSP(args.ssoid, args.filter_list, args.date_range)
 
     planetoid.do_pretend_science()
 
@@ -16,8 +16,14 @@ def main():
     parser.add_argument(
         "-f", "--filters", help="Comma-separated list of filters required.", type=str, default="u,g,r,i,z,y"
     )
-
-    # can add arguments to specify a date range etc later
+    parser.add_argument(
+        "-d",
+        "--date_range",
+        help="Minimum and maximum MJD(TAI) of required observations. Default is to pull all observations.",
+        nargs=2,
+        type=float,
+        default=[60000.0, 67300.0],
+    )
 
     args = parser.parse_args()
 

--- a/src/adler/dataclasses/AdlerPlanetoid.py
+++ b/src/adler/dataclasses/AdlerPlanetoid.py
@@ -11,7 +11,9 @@ from adler.science.DummyScience import DummyScience
 class AdlerPlanetoid:
     """AdlerPlanetoid class. Contains the Observations, MPCORB and SSObject dataclass objects."""
 
-    def __init__(self, ssObjectId, filter_list, observations_by_filter, mpcorb, ssobject, adler_data):
+    def __init__(
+        self, ssObjectId, filter_list, date_range, observations_by_filter, mpcorb, ssobject, adler_data
+    ):
         """Initialises the AdlerPlanetoid object.
 
         Attributes
@@ -21,6 +23,9 @@ class AdlerPlanetoid:
 
         filter_list : list of str
             A comma-separated list of the filters of interest.
+
+        date_range : list of int
+            The minimum and maximum dates of the desired observations.
 
         observations_by_filter : list of Observations objects
             A list of Observations objects holding joined DIASource/SSSource observations of the planetoid specified by ssObjectId. Each item in the list holds observations of a different filter, in the order specified by filter_list.
@@ -37,6 +42,7 @@ class AdlerPlanetoid:
         """
         self.ssObjectId = ssObjectId
         self.filter_list = filter_list
+        self.date_range = date_range
         self.observations_by_filter = observations_by_filter
         self.MPCORB = mpcorb
         self.SSObject = ssobject
@@ -48,7 +54,9 @@ class AdlerPlanetoid:
         pass
 
     @classmethod
-    def construct_from_RSP(cls, ssObjectId, filter_list=["u", "g", "r", "i", "z", "y"]):
+    def construct_from_RSP(
+        cls, ssObjectId, filter_list=["u", "g", "r", "i", "z", "y"], date_range=[60000.0, 67300.0]
+    ):
         """Custom constructor which builds the AdlerPlanetoid object and the associated Observations, MPCORB and SSObject objects
         from the RSP.
 
@@ -60,18 +68,26 @@ class AdlerPlanetoid:
         filter_list : list of str
             A comma-separated list of the filters of interest.
 
+        date_range : list of int
+            The minimum and maximum dates of the desired observations.
+
         """
 
+        if len(date_range) != 2:
+            raise Exception("date_range argument must be of length 2.")
+
         service = get_tap_service("ssotap")
-        observations_by_filter = cls.populate_observations(cls, ssObjectId, filter_list, service=service)
+        observations_by_filter = cls.populate_observations(
+            cls, ssObjectId, filter_list, date_range, service=service
+        )
         mpcorb = cls.populate_MPCORB(cls, ssObjectId, service=service)
         ssobject = cls.populate_SSObject(cls, ssObjectId, filter_list, service=service)
 
         adler_data = AdlerData(filter_list)
 
-        return cls(ssObjectId, filter_list, observations_by_filter, mpcorb, ssobject, adler_data)
+        return cls(ssObjectId, filter_list, date_range, observations_by_filter, mpcorb, ssobject, adler_data)
 
-    def populate_observations(self, ssObjectId, filter_list, service=None, sql_filename=None):
+    def populate_observations(self, ssObjectId, filter_list, date_range, service=None, sql_filename=None):
         """Populates the observations_by_filter class attribute. Can populate from either the RSP for a SQL database:
         this behaviour is controlled by the service and sql_filename parameters, one of which must be supplied.
 
@@ -82,6 +98,9 @@ class AdlerPlanetoid:
 
         filter_list : list of str
             A comma-separated list of the filters of interest.
+
+        date_range : list of int
+            The minimum and maximum dates of the desired observations.
 
         service : pyvo.dal.tap.TAPService object
             TAPService object linked to the RSP. Default=None.
@@ -103,7 +122,7 @@ class AdlerPlanetoid:
                     JOIN dp03_catalogs_10yr.diaSource ON dp03_catalogs_10yr.ssObject.ssObjectId   = dp03_catalogs_10yr.diaSource.ssObjectId
                     JOIN dp03_catalogs_10yr.ssSource  ON dp03_catalogs_10yr.diaSource.diaSourceId = dp03_catalogs_10yr.ssSource.diaSourceId
                 WHERE
-                    ssObject.ssObjectId = {ssObjectId} and band = '{filter_name}'
+                    ssObject.ssObjectId = {ssObjectId} AND band = '{filter_name} AND midpointMjdTai BETWEEN {date_range[0]} AND {date_range[1]}'
                 """
 
             data_table = get_data_table(observations_sql_query, service=service, sql_filename=sql_filename)

--- a/src/adler/dataclasses/AdlerPlanetoid.py
+++ b/src/adler/dataclasses/AdlerPlanetoid.py
@@ -122,7 +122,7 @@ class AdlerPlanetoid:
                     JOIN dp03_catalogs_10yr.diaSource ON dp03_catalogs_10yr.ssObject.ssObjectId   = dp03_catalogs_10yr.diaSource.ssObjectId
                     JOIN dp03_catalogs_10yr.ssSource  ON dp03_catalogs_10yr.diaSource.diaSourceId = dp03_catalogs_10yr.ssSource.diaSourceId
                 WHERE
-                    ssObject.ssObjectId = {ssObjectId} AND band = '{filter_name} AND midpointMjdTai BETWEEN {date_range[0]} AND {date_range[1]}'
+                    ssObject.ssObjectId = {ssObjectId} AND band = '{filter_name}' AND midpointMjdTai BETWEEN {date_range[0]} AND {date_range[1]}
                 """
 
             data_table = get_data_table(observations_sql_query, service=service, sql_filename=sql_filename)


### PR DESCRIPTION
Fixes #36.
- You can now specify a date range, either on the command line or when creating an AdlerPlanetoid object in a Jupyter notebook.
- This is done on the command line with the `-d --date_range` argument (where you simply follow the flag with two numbers) or on AdlerPlanetoid by passing `date_range=[<min_date>, <max_date>]` to `construct_from_RSP()`.
- Dates should be in MJD(TAI).

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
