### PR TITLE
Update smoke-test.yml

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,8 +32,8 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
+        pip install -e .
+        pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: List dependencies
       run: |


### PR DESCRIPTION
Fixes #101.

I already did this for the unit tests but didn't fix the smoke tests. Essentially we need to make sure that the workflow runs `pip install -e .[dev]` with the `-e` so that the repo's directory structure is maintained. If we don't include the -e then the unit tests can't find the testing database.

I don't know why installing without the editable environment flag changes the directory structure from that of the repo and I haven't been able to find out why. Yet.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
