### PR TITLE
AdlerData refactor.

### DIFF
--- a/src/adler/dataclasses/AdlerPlanetoid.py
+++ b/src/adler/dataclasses/AdlerPlanetoid.py
@@ -91,7 +91,7 @@ class AdlerPlanetoid:
             cls, ssObjectId, filter_list, sql_filename=sql_filename, schema=schema
         )
 
-        adler_data = AdlerData(filter_list)
+        adler_data = AdlerData(ssObjectId, filter_list)
 
         return cls(ssObjectId, filter_list, date_range, observations_by_filter, mpcorb, ssobject, adler_data)
 
@@ -125,7 +125,7 @@ class AdlerPlanetoid:
         mpcorb = cls.populate_MPCORB(cls, ssObjectId, service=service)
         ssobject = cls.populate_SSObject(cls, ssObjectId, filter_list, service=service)
 
-        adler_data = AdlerData(filter_list)
+        adler_data = AdlerData(ssObjectId, filter_list)
 
         return cls(ssObjectId, filter_list, date_range, observations_by_filter, mpcorb, ssobject, adler_data)
 

--- a/tests/adler/dataclasses/test_AdlerData.py
+++ b/tests/adler/dataclasses/test_AdlerData.py
@@ -1,102 +1,204 @@
 from numpy.testing import assert_array_equal
 import pytest
+import numpy as np
 
 from adler.dataclasses.AdlerData import AdlerData
 
 
 # setting up the AdlerData object to be used for testing
 
-test_object = AdlerData(["u", "g", "r"])
+test_object = AdlerData(666, ["u", "g", "r"])
 
-test_object.populate_phase_parameters("u", "model_1", 11.0, 12.0, 13, 14.0, 15.0, 16.0, [17.0], [18.0])
-test_object.populate_phase_parameters(
-    "u",
-    model_name="model_2",
-    H=25.0,
-    H_err=26.0,
-    phase_parameters=[27.0, 27.5],
-    phase_parameters_err=[28.0, 28.5],
-)
-test_object.populate_phase_parameters("g", "model_1", 31.0, 32.0, 33, 34.0, 35.0, 36.0, [37.0], [38.0])
-test_object.populate_phase_parameters(
-    "r", "model_2", 41.0, 42.0, 43, 44.0, 45.0, 46.0, [47.0, 47.5], [48.0, 48.5]
-)
+u_model_1 = {
+    "model_name": "model_1",
+    "phaseAngle_min": 11.0,
+    "phaseAngle_range": 12.0,
+    "nobs": 13,
+    "arc": 14.0,
+    "H": 15.0,
+    "H_err": 16.0,
+    "phase_parameter_1": 17.0,
+    "phase_parameter_1_err": 18.0,
+}
+
+u_model_2 = {
+    "model_name": "model_2",
+    "H": 25.0,
+    "H_err": 26.0,
+    "phase_parameter_1": 27.0,
+    "phase_parameter_1_err": 28.0,
+    "phase_parameter_2": 29.0,
+    "phase_parameter_2_err": 30.0,
+}
+
+g_model_1 = {
+    "model_name": "model_1",
+    "phaseAngle_min": 31.0,
+    "phaseAngle_range": 32.0,
+    "nobs": 33,
+    "arc": 34.0,
+    "H": 35.0,
+    "H_err": 36.0,
+    "phase_parameter_1": 37.0,
+    "phase_parameter_1_err": 38.0,
+}
+
+r_model_2 = {
+    "model_name": "model_2",
+    "phaseAngle_min": 41.0,
+    "phaseAngle_range": 42.0,
+    "nobs": 43,
+    "arc": 44.0,
+    "H": 45.0,
+    "H_err": 46.0,
+    "phase_parameter_1": 47.0,
+    "phase_parameter_1_err": 48.0,
+    "phase_parameter_2": 49.0,
+    "phase_parameter_2_err": 50.0,
+}
+
+test_object.populate_phase_parameters("u", **u_model_1)
+test_object.populate_phase_parameters("u", **u_model_2)
+test_object.populate_phase_parameters("g", **g_model_1)
+test_object.populate_phase_parameters("r", **r_model_2)
 
 
 def test_populate_phase_parameters():
     # test to make sure the object is correctly populated
     assert test_object.filter_list == ["u", "g", "r"]
-    assert test_object.model_lists == [["model_1", "model_2"], ["model_1"], ["model_2"]]
 
-    assert_array_equal(test_object.phaseAngle_min_adler, [11.0, 31.0, 41.0])
-    assert_array_equal(test_object.phaseAngle_range_adler, [12.0, 32.0, 42.0])
-    assert_array_equal(test_object.nobs_adler, [13, 33, 43])
-    assert_array_equal(test_object.arc_adler, [14.0, 34.0, 44.0])
+    assert test_object.filter_dependent_values[0].model_list == ["model_1", "model_2"]
+    assert test_object.filter_dependent_values[1].model_list == ["model_1"]
+    assert test_object.filter_dependent_values[2].model_list == ["model_2"]
 
-    assert test_object.H_adler == [[15.0, 25.0], [35.0], [45.0]]
-    assert test_object.H_err_adler == [[16.0, 26.0], [36.0], [46.0]]
-    assert test_object.phase_parameters == [[[17.0], [27.0, 27.5]], [[37.0]], [[47.0, 47.5]]]
-    assert test_object.phase_parameters_err == [[[18.0], [28.0, 28.5]], [[38.0]], [[48.0, 48.5]]]
+    assert_array_equal([a.phaseAngle_min for a in test_object.filter_dependent_values], [11.0, 31.0, 41.0])
+    assert_array_equal([a.phaseAngle_range for a in test_object.filter_dependent_values], [12.0, 32.0, 42.0])
+    assert_array_equal([a.nobs for a in test_object.filter_dependent_values], [13, 33, 43])
+    assert_array_equal([a.arc for a in test_object.filter_dependent_values], [14.0, 34.0, 44.0])
+
+    assert test_object.filter_dependent_values[0].model_dependent_values[0].__dict__ == {
+        "filter_name": "u",
+        "model_name": "model_1",
+        "H": 15.0,
+        "H_err": 16.0,
+        "phase_parameter_1": 17.0,
+        "phase_parameter_1_err": 18.0,
+        "phase_parameter_2": np.nan,
+        "phase_parameter_2_err": np.nan,
+    }
+
+    assert test_object.filter_dependent_values[0].model_dependent_values[1].__dict__ == {
+        "filter_name": "u",
+        "model_name": "model_2",
+        "H": 25.0,
+        "H_err": 26.0,
+        "phase_parameter_1": 27.0,
+        "phase_parameter_1_err": 28.0,
+        "phase_parameter_2": 29.0,
+        "phase_parameter_2_err": 30.0,
+    }
+
+    assert test_object.filter_dependent_values[1].model_dependent_values[0].__dict__ == {
+        "filter_name": "g",
+        "model_name": "model_1",
+        "H": 35.0,
+        "H_err": 36.0,
+        "phase_parameter_1": 37.0,
+        "phase_parameter_1_err": 38.0,
+        "phase_parameter_2": np.nan,
+        "phase_parameter_2_err": np.nan,
+    }
+
+    assert test_object.filter_dependent_values[2].model_dependent_values[0].__dict__ == {
+        "filter_name": "r",
+        "model_name": "model_2",
+        "H": 45.0,
+        "H_err": 46.0,
+        "phase_parameter_1": 47.0,
+        "phase_parameter_1_err": 48.0,
+        "phase_parameter_2": 49.0,
+        "phase_parameter_2_err": 50.0,
+    }
 
     # check to make sure model-dependent parameter is correctly updated (then return it to previous)
-    test_object.populate_phase_parameters("u", "model_1", H=99.0)
-    assert test_object.H_adler[0][0] == 99.0
-    test_object.populate_phase_parameters("u", "model_1", H=15.0)
+    test_object.populate_phase_parameters("u", model_name="model_1", H=99.0)
+    assert test_object.filter_dependent_values[0].model_dependent_values[0].H == 99.0
+    test_object.populate_phase_parameters("u", model_name="model_1", H=15.0)
 
     # check to make sure filter-dependent parameter is correctly updated (then return it to previous)
-    test_object.populate_phase_parameters("u", nobs=99)
-    assert test_object.nobs_adler[0] == 99
-    test_object.populate_phase_parameters("u", nobs=13)
 
     # testing to make sure the correct error messages trigger
-    with pytest.raises(TypeError) as error_info_1:
-        test_object.populate_phase_parameters("u", "model_1", 11.0, 12.0, 13, 14.0, 15.0, 16.0, 17.0, 18.0)
+    with pytest.raises(ValueError) as error_info_1:
+        test_object.populate_phase_parameters("y")
 
-    assert (
-        error_info_1.value.args[0]
-        == "Both phase_parameters and phase_parameters_err arguments must be lists."
-    )
+    assert error_info_1.value.args[0] == "Filter y does not exist in AdlerData.filter_list."
 
-    with pytest.raises(ValueError) as error_info_2:
-        test_object.populate_phase_parameters("y", "model_1", 11.0, 12.0, 13, 14.0, 15.0, 16.0, 17.0, 18.0)
-
-    assert error_info_2.value.args[0] == "Filter y does not exist in AdlerData.filter_list."
-
-    with pytest.raises(Exception) as error_info_3:
+    with pytest.raises(NameError) as error_info_2:
         test_object.populate_phase_parameters("u", H=4.0)
 
-    assert error_info_3.value.args[0] == "No model name given. Cannot update model-specific phase_parameters."
+    assert error_info_2.value.args[0] == "No model name given. Cannot update model-specific phase parameters."
 
 
 def test_get_phase_parameters_in_filter():
-    u_model2 = {
+    assert test_object.get_phase_parameters_in_filter("u", "model_1").__dict__ == {
+        "filter_name": "u",
         "phaseAngle_min": 11.0,
         "phaseAngle_range": 12.0,
         "nobs": 13,
         "arc": 14.0,
-        "H": 25.0,
-        "H_err": 26.0,
-        "phase_parameters": [27.0, 27.5],
-        "phase_parameters_err": [28.0, 28.5],
-    }
-
-    u_model1 = {
-        "phaseAngle_min": 11.0,
-        "phaseAngle_range": 12.0,
-        "nobs": 13,
-        "arc": 14.0,
+        "model_name": "model_1",
         "H": 15.0,
         "H_err": 16.0,
-        "phase_parameters": [17.0],
-        "phase_parameters_err": [18.0],
+        "phase_parameter_1": 17.0,
+        "phase_parameter_1_err": 18.0,
+        "phase_parameter_2": np.nan,
+        "phase_parameter_2_err": np.nan,
     }
 
-    u_independent = {"phaseAngle_min": 11.0, "phaseAngle_range": 12.0, "nobs": 13, "arc": 14.0}
+    assert test_object.get_phase_parameters_in_filter("u", "model_2").__dict__ == {
+        "filter_name": "u",
+        "phaseAngle_min": 11.0,
+        "phaseAngle_range": 12.0,
+        "nobs": 13,
+        "arc": 14.0,
+        "model_name": "model_2",
+        "H": 25.0,
+        "H_err": 26.0,
+        "phase_parameter_1": 27.0,
+        "phase_parameter_1_err": 28.0,
+        "phase_parameter_2": 29.0,
+        "phase_parameter_2_err": 30.0,
+    }
 
-    # making sure the correct parameters are retreived
-    assert test_object.get_phase_parameters_in_filter("u", model_name="model_2") == u_model2
-    assert test_object.get_phase_parameters_in_filter("u", model_name="model_1") == u_model1
-    assert test_object.get_phase_parameters_in_filter("u") == u_independent
+    assert test_object.get_phase_parameters_in_filter("g", "model_1").__dict__ == {
+        "filter_name": "g",
+        "phaseAngle_min": 31.0,
+        "phaseAngle_range": 32.0,
+        "nobs": 33,
+        "arc": 34.0,
+        "model_name": "model_1",
+        "H": 35.0,
+        "H_err": 36.0,
+        "phase_parameter_1": 37.0,
+        "phase_parameter_1_err": 38.0,
+        "phase_parameter_2": np.nan,
+        "phase_parameter_2_err": np.nan,
+    }
+
+    assert test_object.get_phase_parameters_in_filter("r", "model_2").__dict__ == {
+        "filter_name": "r",
+        "phaseAngle_min": 41.0,
+        "phaseAngle_range": 42.0,
+        "nobs": 43,
+        "arc": 44.0,
+        "model_name": "model_2",
+        "H": 45.0,
+        "H_err": 46.0,
+        "phase_parameter_1": 47.0,
+        "phase_parameter_1_err": 48.0,
+        "phase_parameter_2": 49.0,
+        "phase_parameter_2_err": 50.0,
+    }
 
     # checking the error messages
     with pytest.raises(ValueError) as error_info_1:
@@ -117,6 +219,6 @@ def test_print_data(capsys):
     # get what was printed to the terminal
     captured = capsys.readouterr()
 
-    expected = "Phase parameters (per filter):\n\nFilter: u\nPhase angle minimum: 11.0\nPhase angle range: 12.0\nNumber of observations: 13\nArc: 14.0\nModel: model_1.\n\tH: 15.0\n\tH error: 16.0\n\tPhase parameter(s): [17.0]\n\tPhase parameter(s) error: [18.0]\nModel: model_2.\n\tH: 25.0\n\tH error: 26.0\n\tPhase parameter(s): [27.0, 27.5]\n\tPhase parameter(s) error: [28.0, 28.5]\n\n\nFilter: g\nPhase angle minimum: 31.0\nPhase angle range: 32.0\nNumber of observations: 33\nArc: 34.0\nModel: model_1.\n\tH: 35.0\n\tH error: 36.0\n\tPhase parameter(s): [37.0]\n\tPhase parameter(s) error: [38.0]\n\n\nFilter: r\nPhase angle minimum: 41.0\nPhase angle range: 42.0\nNumber of observations: 43\nArc: 44.0\nModel: model_2.\n\tH: 45.0\n\tH error: 46.0\n\tPhase parameter(s): [47.0, 47.5]\n\tPhase parameter(s) error: [48.0, 48.5]\n\n\n"
+    expected = "Filter: u\nPhase angle minimum: 11.0\nPhase angle range: 12.0\nNumber of observations: 13\nArc: 14.0\nModel: model_1.\n\tH: 15.0\n\tH error: 16.0\n\tPhase parameter 1: 17.0\n\tPhase parameter 1 error: 18.0\n\tPhase parameter 2: nan\n\tPhase parameter 2 error: nan\nModel: model_2.\n\tH: 25.0\n\tH error: 26.0\n\tPhase parameter 1: 27.0\n\tPhase parameter 1 error: 28.0\n\tPhase parameter 2: 29.0\n\tPhase parameter 2 error: 30.0\n\n\nFilter: g\nPhase angle minimum: 31.0\nPhase angle range: 32.0\nNumber of observations: 33\nArc: 34.0\nModel: model_1.\n\tH: 35.0\n\tH error: 36.0\n\tPhase parameter 1: 37.0\n\tPhase parameter 1 error: 38.0\n\tPhase parameter 2: nan\n\tPhase parameter 2 error: nan\n\n\nFilter: r\nPhase angle minimum: 41.0\nPhase angle range: 42.0\nNumber of observations: 43\nArc: 44.0\nModel: model_2.\n\tH: 45.0\n\tH error: 46.0\n\tPhase parameter 1: 47.0\n\tPhase parameter 1 error: 48.0\n\tPhase parameter 2: 49.0\n\tPhase parameter 2 error: 50.0\n\n\n"
 
     assert captured.out == expected


### PR DESCRIPTION
Refactor ahead of #69.

Essentially, while working on the above issue, I realised that AdlerData in its current state was too confusing on the developer end and I was struggling to work with it. The user-end is mostly unchanged apart from some exceptions listed below.

Changes on the developer end:
- AdlerData now stores a list of FilterDependentAdler objects to store filter-dependent values. These in turn store lists of PhaseModelDependentAdler objects to store the phase model-dependent values. This replaces the nested lists and is much more consistent with the behaviour of the rest of the code. This is also more scaleable: new dataclasses can be created and attached similarly as Adler calculates more values. Also, it doesn't break my brain.
- The names of the various filter-dependent and model-dependent attributes are stored in lists as global variables. This allows iteration in `populate_phase_parameters()`.
- Updated unit tests.

Changes on the user-end:
- AdlerData now needs to be initialised with both the ssObjectId and the filter list.
- Instead of supplying lists of phase_parameters and phase_parameters_err to `populate_phase_parameters()`, instead supply single values: phase_parameter_1, phase_parameter_1_err, phase_parameter_2, phase_parameter_2_err.
- `populate_phase_parameters()` takes **kwargs now so all keyword arguments must be attributed properly.
- `get_phase_parameters_in_filter()` returns an object instead of a dictionary. This brings it in line with the rest of the code: all similar functions also return objects.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
