### PR TITLE
Smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest','ubuntu-latest']
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest','ubuntu-latest']
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #107 

Looks like there is no 3.9 python available for ARM mac so moving to 3.10,3.11, and 3.12 for the tests 
