### PR TITLE
Adding output CL arguments, setting up logging.

### DIFF
--- a/src/adler/adler.py
+++ b/src/adler/adler.py
@@ -1,3 +1,4 @@
+import logging
 import argparse
 import astropy.units as u
 
@@ -6,12 +7,20 @@ from adler.science.PhaseCurve import PhaseCurve
 from adler.utilities.AdlerCLIArguments import AdlerCLIArguments
 from adler.utilities.adler_logging import setup_adler_logging
 
+logger = logging.getLogger(__name__)
 
 def runAdler(cli_args):
+
+    logger.info("Beginning Adler.")
+    logger.info("Ingesting all data for object {} from RSP...".format(cli_args.ssObjectId))
+  
     planetoid = AdlerPlanetoid.construct_from_RSP(
         cli_args.ssObjectId, cli_args.filter_list, cli_args.date_range
     )
 
+    logger.info("Data successfully ingested.")
+    logger.info("Calculating phase curves...")
+    
     # now let's do some phase curves!
 
     # get the r filter SSObject metadata

--- a/src/adler/adler.py
+++ b/src/adler/adler.py
@@ -9,18 +9,18 @@ from adler.utilities.adler_logging import setup_adler_logging
 
 logger = logging.getLogger(__name__)
 
-def runAdler(cli_args):
 
+def runAdler(cli_args):
     logger.info("Beginning Adler.")
     logger.info("Ingesting all data for object {} from RSP...".format(cli_args.ssObjectId))
-  
+
     planetoid = AdlerPlanetoid.construct_from_RSP(
         cli_args.ssObjectId, cli_args.filter_list, cli_args.date_range
     )
 
     logger.info("Data successfully ingested.")
     logger.info("Calculating phase curves...")
-    
+
     # now let's do some phase curves!
 
     # get the r filter SSObject metadata

--- a/src/adler/adler.py
+++ b/src/adler/adler.py
@@ -4,6 +4,7 @@ import astropy.units as u
 from adler.dataclasses.AdlerPlanetoid import AdlerPlanetoid
 from adler.science.PhaseCurve import PhaseCurve
 from adler.utilities.AdlerCLIArguments import AdlerCLIArguments
+from adler.utilities.adler_logging import setup_adler_logging
 
 
 def runAdler(cli_args):
@@ -37,7 +38,7 @@ def runAdler(cli_args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Runs Adler for a select planetoid and given user input.")
+    parser = argparse.ArgumentParser(description="Runs Adler for select planetoid(s) and given user input.")
 
     parser.add_argument("-s", "--ssObjectId", help="SSObject ID of planetoid.", type=str, required=True)
     parser.add_argument(
@@ -56,10 +57,28 @@ def main():
         type=float,
         default=[60000.0, 67300.0],
     )
+    parser.add_argument(
+        "-o",
+        "--outpath",
+        help="Output path location. Default is current working directory.",
+        type=str,
+        default="./",
+    )
+    parser.add_argument(
+        "-n",
+        "--db_name",
+        help="Stem filename of output database. If this doesn't exist, it will be created. Default: adler_out.",
+        type=str,
+        default="adler_out",
+    )
 
     args = parser.parse_args()
 
     cli_args = AdlerCLIArguments(args)
+
+    adler_logger = setup_adler_logging(cli_args.outpath)
+
+    cli_args.logger = adler_logger
 
     runAdler(cli_args)
 

--- a/src/adler/dataclasses/AdlerData.py
+++ b/src/adler/dataclasses/AdlerData.py
@@ -15,6 +15,8 @@ MODEL_DEPENDENT_KEYS = [
     "phase_parameter_2_err",
 ]
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class AdlerData:

--- a/src/adler/dataclasses/AdlerData.py
+++ b/src/adler/dataclasses/AdlerData.py
@@ -185,7 +185,8 @@ class AdlerData:
             try:
                 model_index = self.filter_dependent_values[filter_index].model_list.index(model_name)
             except ValueError:
-                logger.error("ValueError: Model {} does not exist for filter {} in AdlerData.model_lists.".format(
+                logger.error(
+                    "ValueError: Model {} does not exist for filter {} in AdlerData.model_lists.".format(
                         model_name, filter_name
                     )
                 )

--- a/src/adler/dataclasses/AdlerData.py
+++ b/src/adler/dataclasses/AdlerData.py
@@ -73,10 +73,12 @@ class AdlerData:
         try:
             filter_index = self.filter_list.index(filter_name)
         except ValueError:
+            logger.error("ValueError: Filter {} does not exist in AdlerData.filter_list.".format(filter_name))
             raise ValueError("Filter {} does not exist in AdlerData.filter_list.".format(filter_name))
 
         # if model-dependent parameters exist without a model name, return an error
         if not kwargs.get("model_name") and any(name in kwargs for name in MODEL_DEPENDENT_KEYS):
+            logger.error("NameError: No model name given. Cannot update model-specific phase parameters.")
             raise NameError("No model name given. Cannot update model-specific phase parameters.")
 
         # update the value if it's in **kwargs
@@ -166,6 +168,7 @@ class AdlerData:
         try:
             filter_index = self.filter_list.index(filter_name)
         except ValueError:
+            logger.error("ValueError: Filter {} does not exist in AdlerData.filter_list.".format(filter_name))
             raise ValueError("Filter {} does not exist in AdlerData.filter_list.".format(filter_name))
 
         output_obj = PhaseParameterOutput()
@@ -176,11 +179,16 @@ class AdlerData:
         output_obj.arc = self.filter_dependent_values[filter_index].arc
 
         if not model_name:
+            logger.warn("No model name was specified. Returning non-model-dependent phase parameters.")
             print("No model name specified. Returning non-model-dependent phase parameters.")
         else:
             try:
                 model_index = self.filter_dependent_values[filter_index].model_list.index(model_name)
             except ValueError:
+                logger.error("ValueError: Model {} does not exist for filter {} in AdlerData.model_lists.".format(
+                        model_name, filter_name
+                    )
+                )
                 raise ValueError(
                     "Model {} does not exist for filter {} in AdlerData.model_lists.".format(
                         model_name, filter_name

--- a/src/adler/dataclasses/AdlerData.py
+++ b/src/adler/dataclasses/AdlerData.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import logging
 import numpy as np
 from dataclasses import dataclass, field
 from datetime import datetime, timezone

--- a/src/adler/dataclasses/AdlerPlanetoid.py
+++ b/src/adler/dataclasses/AdlerPlanetoid.py
@@ -91,13 +91,17 @@ class AdlerPlanetoid:
         )
 
         if len(observations_by_filter) == 0:
-            logger.error("No observations found for this object in the given filter(s). Check SSOID and try again.")
+            logger.error(
+                "No observations found for this object in the given filter(s). Check SSOID and try again."
+            )
             raise Exception(
                 "No observations found for this object in the given filter(s). Check SSOID and try again."
             )
 
         if len(filter_list) > len(observations_by_filter):
-            logger.info("Not all specified filters have observations. Recalculating filter list based on past observations.")
+            logger.info(
+                "Not all specified filters have observations. Recalculating filter list based on past observations."
+            )
             filter_list = [obs_object.filter_name for obs_object in observations_by_filter]
             logger.info("New filter list is: {}".format(filter_list))
 
@@ -140,13 +144,17 @@ class AdlerPlanetoid:
         )
 
         if len(observations_by_filter) == 0:
-            logger.error("No observations found for this object in the given filter(s). Check SSOID and try again.")
+            logger.error(
+                "No observations found for this object in the given filter(s). Check SSOID and try again."
+            )
             raise Exception(
                 "No observations found for this object in the given filter(s). Check SSOID and try again."
             )
 
         if len(filter_list) > len(observations_by_filter):
-            logger.info("Not all specified filters have observations. Recalculating filter list based on past observations.")
+            logger.info(
+                "Not all specified filters have observations. Recalculating filter list based on past observations."
+            )
             filter_list = [obs_object.filter_name for obs_object in observations_by_filter]
             logger.info("New filter list is: {}".format(filter_list))
 
@@ -216,7 +224,11 @@ class AdlerPlanetoid:
             data_table = get_data_table(observations_sql_query, service=service, sql_filename=sql_filename)
 
             if len(data_table) == 0:
-                logger.warning("No observations found in {} filter for this object. Skipping this filter.".format(filter_name))
+                logger.warning(
+                    "No observations found in {} filter for this object. Skipping this filter.".format(
+                        filter_name
+                    )
+                )
                 print(
                     "WARNING: No observations found in {} filter for this object. Skipping this filter.".format(
                         filter_name

--- a/src/adler/dataclasses/AdlerPlanetoid.py
+++ b/src/adler/dataclasses/AdlerPlanetoid.py
@@ -1,11 +1,14 @@
 from lsst.rsp import get_tap_service
 import pandas as pd
+import logging
 
 from adler.dataclasses.Observations import Observations
 from adler.dataclasses.MPCORB import MPCORB
 from adler.dataclasses.SSObject import SSObject
 from adler.dataclasses.AdlerData import AdlerData
 from adler.dataclasses.dataclass_utilities import get_data_table
+
+logger = logging.getLogger(__name__)
 
 
 class AdlerPlanetoid:

--- a/src/adler/dataclasses/dataclass_utilities.py
+++ b/src/adler/dataclasses/dataclass_utilities.py
@@ -3,6 +3,8 @@ import pandas as pd
 import sqlite3
 import warnings
 
+logger = logging.getLogger(__name__)
+
 
 def get_data_table(sql_query, service=None, sql_filename=None):
     """Gets a table of data based on a SQL query. Table is pulled from either the RSP or a local SQL database:

--- a/src/adler/dataclasses/dataclass_utilities.py
+++ b/src/adler/dataclasses/dataclass_utilities.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import sqlite3
 import warnings
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/adler/dataclasses/dataclass_utilities.py
+++ b/src/adler/dataclasses/dataclass_utilities.py
@@ -88,12 +88,14 @@ def get_from_table(data_table, column_name, data_type, table_name="default"):
             elif data_type == np.ndarray:
                 data_val = np.array(data_table[column_name])
             else:
+                logger.error("TypeError: Type for argument data_type not recognised for column {} in table {}: must be str, float, int or np.ndarray.".format(column_name, table_name))
                 raise TypeError(
                     "Type for argument data_type not recognised for column {} in table {}: must be str, float, int or np.ndarray.".format(
                         column_name, table_name
                     )
                 )
         except ValueError:
+            logger.error("ValueError: Could not cast column name to type.")
             raise ValueError("Could not cast column name to type.")
 
     # here we alert the user if one of the values is unpopulated and change it to a NaN
@@ -132,6 +134,7 @@ def check_value_populated(data_val, data_type, column_name, table_name):
     str_is_empty = data_type == str and len(data_val) == 0
 
     if array_length_zero or number_is_nan or str_is_empty:
+        logger.warning("{} unpopulated in {} table for this object. Storing NaN instead.".format(column_name, table_name))
         print(
             "WARNING: {} unpopulated in {} table for this object. Storing NaN instead.".format(
                 column_name, table_name

--- a/src/adler/dataclasses/dataclass_utilities.py
+++ b/src/adler/dataclasses/dataclass_utilities.py
@@ -88,7 +88,11 @@ def get_from_table(data_table, column_name, data_type, table_name="default"):
             elif data_type == np.ndarray:
                 data_val = np.array(data_table[column_name])
             else:
-                logger.error("TypeError: Type for argument data_type not recognised for column {} in table {}: must be str, float, int or np.ndarray.".format(column_name, table_name))
+                logger.error(
+                    "TypeError: Type for argument data_type not recognised for column {} in table {}: must be str, float, int or np.ndarray.".format(
+                        column_name, table_name
+                    )
+                )
                 raise TypeError(
                     "Type for argument data_type not recognised for column {} in table {}: must be str, float, int or np.ndarray.".format(
                         column_name, table_name
@@ -134,7 +138,9 @@ def check_value_populated(data_val, data_type, column_name, table_name):
     str_is_empty = data_type == str and len(data_val) == 0
 
     if array_length_zero or number_is_nan or str_is_empty:
-        logger.warning("{} unpopulated in {} table for this object. Storing NaN instead.".format(column_name, table_name))
+        logger.warning(
+            "{} unpopulated in {} table for this object. Storing NaN instead.".format(column_name, table_name)
+        )
         print(
             "WARNING: {} unpopulated in {} table for this object. Storing NaN instead.".format(
                 column_name, table_name

--- a/src/adler/utilities/AdlerCLIArguments.py
+++ b/src/adler/utilities/AdlerCLIArguments.py
@@ -1,3 +1,6 @@
+import os
+
+
 class AdlerCLIArguments:
     """
     Class for storing abd validating Adler command-line arguments.
@@ -13,6 +16,8 @@ class AdlerCLIArguments:
         self.ssObjectId = args.ssObjectId
         self.filter_list = args.filter_list
         self.date_range = args.date_range
+        self.outpath = args.outpath
+        self.db_name = args.db_name
 
         self.validate_arguments()
 
@@ -20,20 +25,21 @@ class AdlerCLIArguments:
         self._validate_filter_list()
         self._validate_ssObjectId()
         self._validate_date_range()
+        self._validate_outpath()
 
     def _validate_filter_list(self):
         expected_filters = ["u", "g", "r", "i", "z", "y"]
 
         if not set(self.filter_list).issubset(expected_filters):
             raise ValueError(
-                "Unexpected filters found in filter_list command-line argument. filter_list must be a list of LSST filters."
+                "Unexpected filters found in --filter_list command-line argument. --filter_list must be a list of LSST filters."
             )
 
     def _validate_ssObjectId(self):
         try:
             int(self.ssObjectId)
         except ValueError:
-            raise ValueError("ssObjectId command-line argument does not appear to be a valid ssObjectId.")
+            raise ValueError("--ssObjectId command-line argument does not appear to be a valid ssObjectId.")
 
     def _validate_date_range(self):
         for d in self.date_range:
@@ -41,10 +47,17 @@ class AdlerCLIArguments:
                 float(d)
             except ValueError:
                 raise ValueError(
-                    "One or both of the values for the date_range command-line argument do not seem to be valid numbers."
+                    "One or both of the values for the --date_range command-line argument do not seem to be valid numbers."
                 )
 
         if any(d > 250000 for d in self.date_range):
             raise ValueError(
-                "Dates for date_range command-line argument seem rather large. Did you input JD instead of MJD?"
+                "Dates for --date_range command-line argument seem rather large. Did you input JD instead of MJD?"
             )
+
+    def _validate_outpath(self):
+        # make it an absolute path if it's relative!
+        self.outpath = os.path.abspath(self.outpath)
+
+        if not os.path.isdir(self.outpath):
+            raise ValueError("The output path for the command-line argument --outpath cannot be found.")

--- a/src/adler/utilities/adler_logging.py
+++ b/src/adler/utilities/adler_logging.py
@@ -1,0 +1,39 @@
+import logging
+import os
+from datetime import datetime
+
+
+def setup_adler_logging(
+    log_location,
+    log_format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s ",
+    log_name="",
+    log_file_info="adler.log",
+    log_file_error="adler.err",
+):
+    log = logging.getLogger(log_name)
+    log_formatter = logging.Formatter(log_format)
+
+    # comment this to suppress console output
+    # stream_handler = logging.StreamHandler()
+    # stream_handler.setFormatter(log_formatter)
+    # log.addHandler(stream_handler)
+
+    dstr = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    cpid = os.getpid()
+
+    log_file_info = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_info)
+    log_file_error = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_error)
+
+    file_handler_info = logging.FileHandler(log_file_info, mode="w")
+    file_handler_info.setFormatter(log_formatter)
+    file_handler_info.setLevel(logging.INFO)
+    log.addHandler(file_handler_info)
+
+    file_handler_error = logging.FileHandler(log_file_error, mode="w")
+    file_handler_error.setFormatter(log_formatter)
+    file_handler_error.setLevel(logging.ERROR)
+    log.addHandler(file_handler_error)
+
+    log.setLevel(logging.INFO)
+
+    return log

--- a/src/adler/utilities/adler_logging.py
+++ b/src/adler/utilities/adler_logging.py
@@ -24,16 +24,19 @@ def setup_adler_logging(
     log_file_info = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_info)
     log_file_error = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_error)
 
+    # this log will log pretty much everything: basic info, but also warnings and errors
     file_handler_info = logging.FileHandler(log_file_info, mode="w")
     file_handler_info.setFormatter(log_formatter)
     file_handler_info.setLevel(logging.INFO)
     log.addHandler(file_handler_info)
 
+    # this log only logs warnings and errors, so they can be looked at quickly without a lot of scrolling
     file_handler_error = logging.FileHandler(log_file_error, mode="w")
     file_handler_error.setFormatter(log_formatter)
-    file_handler_error.setLevel(logging.ERROR)
+    file_handler_error.setLevel(logging.WARN)
     log.addHandler(file_handler_error)
 
+    # I don't know why we need this line but info logging doesn't work without it, upsettingly
     log.setLevel(logging.INFO)
 
     return log

--- a/tests/adler/utilities/test_AdlerCLIArguments.py
+++ b/tests/adler/utilities/test_AdlerCLIArguments.py
@@ -1,73 +1,104 @@
+import os
 import pytest
 from adler.utilities.AdlerCLIArguments import AdlerCLIArguments
 
 
 # AdlerCLIArguments object takes an object as input, so we define a quick one here
 class args:
-    def __init__(self, ssObjectId, filter_list, date_range):
+    def __init__(self, ssObjectId, filter_list, date_range, outpath, db_name):
         self.ssObjectId = ssObjectId
         self.filter_list = filter_list
         self.date_range = date_range
+        self.outpath = outpath
+        self.db_name = db_name
 
 
-def test_AdlerCLIArguments():
+def test_AdlerCLIArguments_population():
     # test correct population
-    good_input_dict = {"ssObjectId": "666", "filter_list": ["g", "r", "i"], "date_range": [60000.0, 67300.0]}
+    good_input_dict = {
+        "ssObjectId": "666",
+        "filter_list": ["g", "r", "i"],
+        "date_range": [60000.0, 67300.0],
+        "outpath": "./",
+        "db_name": "output",
+    }
     good_arguments = args(**good_input_dict)
     good_arguments_object = AdlerCLIArguments(good_arguments)
 
+    good_input_dict["outpath"] = os.path.abspath("./")
+
     assert good_arguments_object.__dict__ == good_input_dict
 
+
+def test_AdlerCLIArguments_badSSOID():
     # test that a bad ssObjectId triggers the right error
-    bad_ssoid_arguments = args("hello!", ["g", "r", "i"], [60000.0, 67300.0])
+    bad_ssoid_arguments = args("hello!", ["g", "r", "i"], [60000.0, 67300.0], "./", "output")
 
     with pytest.raises(ValueError) as bad_ssoid_error:
         bad_ssoid_object = AdlerCLIArguments(bad_ssoid_arguments)
 
     assert (
         bad_ssoid_error.value.args[0]
-        == "ssObjectId command-line argument does not appear to be a valid ssObjectId."
+        == "--ssObjectId command-line argument does not appear to be a valid ssObjectId."
     )
 
+
+def test_AdlerCLIArguments_badfilters():
     # test that non-LSST or unexpected filters trigger the right error
-    bad_filter_arguments = args("666", ["g", "r", "i", "m"], [60000.0, 67300.0])
+    bad_filter_arguments = args("666", ["g", "r", "i", "m"], [60000.0, 67300.0], "./", "output")
 
     with pytest.raises(ValueError) as bad_filter_error:
         bad_filter_object = AdlerCLIArguments(bad_filter_arguments)
 
     assert (
         bad_filter_error.value.args[0]
-        == "Unexpected filters found in filter_list command-line argument. filter_list must be a list of LSST filters."
+        == "Unexpected filters found in --filter_list command-line argument. --filter_list must be a list of LSST filters."
     )
 
-    bad_filter_arguments_2 = args("666", ["pony"], [60000.0, 67300.0])
+    bad_filter_arguments_2 = args("666", ["pony"], [60000.0, 67300.0], "./", "output")
 
     with pytest.raises(ValueError) as bad_filter_error_2:
         bad_filter_object = AdlerCLIArguments(bad_filter_arguments_2)
 
     assert (
         bad_filter_error_2.value.args[0]
-        == "Unexpected filters found in filter_list command-line argument. filter_list must be a list of LSST filters."
+        == "Unexpected filters found in --filter_list command-line argument. --filter_list must be a list of LSST filters."
     )
 
+
+def test_AdlerCLIArguments_baddates():
     # test that overly-large dates trigger the right error
-    big_date_arguments = args("666", ["g", "r", "i"], [260000.0, 267300.0])
+    big_date_arguments = args("666", ["g", "r", "i"], [260000.0, 267300.0], "./", "output")
 
     with pytest.raises(ValueError) as big_date_error:
         big_date_object = AdlerCLIArguments(big_date_arguments)
 
     assert (
         big_date_error.value.args[0]
-        == "Dates for date_range command-line argument seem rather large. Did you input JD instead of MJD?"
+        == "Dates for --date_range command-line argument seem rather large. Did you input JD instead of MJD?"
     )
 
     # test that unexpected date values trigger the right error
-    bad_date_arguments = args("666", ["g", "r", "i"], [260000.0, "cheese"])
+    bad_date_arguments = args("666", ["g", "r", "i"], [60000.0, "cheese"], "./", "output")
 
     with pytest.raises(ValueError) as bad_date_error:
         bad_date_object = AdlerCLIArguments(bad_date_arguments)
 
     assert (
         bad_date_error.value.args[0]
-        == "One or both of the values for the date_range command-line argument do not seem to be valid numbers."
+        == "One or both of the values for the --date_range command-line argument do not seem to be valid numbers."
+    )
+
+
+def test_AdlerCLIArguments_badoutput():
+    bad_output_arguments = args(
+        "666", ["g", "r", "i"], [60000.0, 67300.0], "./definitely_fake_folder/", "output"
+    )
+
+    with pytest.raises(ValueError) as bad_output_error:
+        bad_output_object = AdlerCLIArguments(bad_output_arguments)
+
+    assert (
+        bad_output_error.value.args[0]
+        == "The output path for the command-line argument --outpath cannot be found."
     )

--- a/tests/adler/utilities/test_adler_logging.py
+++ b/tests/adler/utilities/test_adler_logging.py
@@ -1,0 +1,40 @@
+import glob
+import os
+import pytest
+import tempfile
+
+
+def test_setup_adler_logging():
+    from adler.utilities.adler_logging import setup_adler_logging
+
+    with tempfile.TemporaryDirectory() as dir_name:
+        logger = setup_adler_logging(dir_name)
+
+        # Check that the files get created.
+        errlog = glob.glob(os.path.join(dir_name, "*-adler.err"))
+        datalog = glob.glob(os.path.join(dir_name, "*-adler.log"))
+
+        assert os.path.exists(errlog[0])
+        assert os.path.exists(datalog[0])
+
+        # Log some information.
+        logger.info("Test1")
+        logger.info("Test2")
+        logger.error("Error1")
+        logger.info("Test3")
+
+        # Check that all five lines exist in the INFO file.
+        with open(datalog[0], "r") as f_info:
+            log_data = f_info.read()
+            assert "Test1" in log_data
+            assert "Test2" in log_data
+            assert "Error1" in log_data
+            assert "Test3" in log_data
+
+        # Check that only error and critical lines exist in the ERROR file.
+        with open(errlog[0], "r") as f_err:
+            log_data = f_err.read()
+            assert "Test1" not in log_data
+            assert "Test2" not in log_data
+            assert "Error1" in log_data
+            assert "Test3" not in log_data


### PR DESCRIPTION
Fixes #109.
- Added command-line arguments to let the user specify an output path and the database name to write to. We will need this anyway, and I also need a place to save the logs.
- Wrote a unit test to cover the new arguments.
- Wrote a function to set up logging for Adler.
- Added log set-up to dataclasses.
- Ensured current warnings/errors are written to the log.
- Added informative logging messages.
- Added a unit test for the setup function.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
